### PR TITLE
set background-color to html element

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -106,7 +106,7 @@ html {
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
 	box-sizing: border-box;
-	background: radial-gradient(circle, #300e29 0%, #130414 100%);
+	background: radial-gradient(circle, #300e29 0%, #130414 100%), #000000;
 	color: white;
 }
 


### PR DESCRIPTION
スクロール時に上と下の白い部分が見えてしまうやつです

before
<img width="634" alt="ss 2019-04-28 13 29 10" src="https://user-images.githubusercontent.com/11515982/56858708-c961b200-69b9-11e9-8c79-c86395890372.png">



after
<img width="622" alt="ss 2019-04-28 12 50 55" src="https://user-images.githubusercontent.com/11515982/56858700-88699d80-69b9-11e9-85a6-2b4c68d15de7.png">

